### PR TITLE
Fixed typographical error, changed Britian to Britain in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ a shape-file (in the `~/.shape_files/` directory) and works directly from that.
     <img
     src="https://raw.githubusercontent.com/ga7g08/pymapgb/master/examples/countries.png"
     alt="" height="400" width="350">
-    <figcaption> Countries of Great Britian
+    <figcaption> Countries of Great Britain
     </figure>
     </a>
 <br />


### PR DESCRIPTION
ga7g08, I've corrected a typographical error in the documentation of the [pymapgb](https://github.com/ga7g08/pymapgb) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
